### PR TITLE
Fix iOS 16 issue with `WebFrameRepresentable`

### DIFF
--- a/Sources/Peregrine/WebFrame.swift
+++ b/Sources/Peregrine/WebFrame.swift
@@ -16,8 +16,6 @@
 import WebKit
 
 public final class WebFrame: Frame {
-    public let view = WebFrameRepresentable()
-
     internal let configuration: Configuration
     internal let appServer: FileServer?
     internal let rpcServer: RPCServer
@@ -79,8 +77,11 @@ public final class WebFrame: Frame {
         )
 
         rpcServer = RPCServer(configuration: rpcServerConfiguration)
-        view.frame = self
     }
+
+    public lazy var view: WebFrameRepresentable = {
+        return WebFrameRepresentable(frame: self)
+    }()
 
     /// Load the WebView and prepare for display.
     ///

--- a/Sources/Peregrine/WebFrameRepresentable.swift
+++ b/Sources/Peregrine/WebFrameRepresentable.swift
@@ -16,24 +16,16 @@
 import SwiftUI
 import WebKit
 
-public final class WebFrameRepresentable: UIViewRepresentable {
+public struct WebFrameRepresentable: UIViewRepresentable {
+    public let frame: WebFrame
+
     public typealias UIViewType = WKWebView
 
-    internal weak var frame: WebFrame?
-
-    private var _frame: WebFrame {
-        guard let frame = frame else {
-            fatalError("WebFrameRepresentable lost reference to WebFrame.")
-        }
-
-        return frame
-    }
-
-    public final func makeUIView(context _: Context) -> WKWebView {
-        let webView = _frame.webView
-        _frame.loadBaseURL()
+    public func makeUIView(context _: Context) -> WKWebView {
+        let webView = frame.webView
+        frame.loadBaseURL()
         return webView
     }
 
-    public final func updateUIView(_: WKWebView, context _: Context) {}
+    public func updateUIView(_: WKWebView, context _: Context) {}
 }


### PR DESCRIPTION
Fixes the following compile issue with iOS 16 targets:

> Fatal error: UIViewRepresentables must be value types: WebFrameRepresentable